### PR TITLE
update to 5.0.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/async_timeout-{{ version }}.tar.gz
   sha256: d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "async-timeout" %}
-{% set version = "4.0.3" %}
+{% set version = "5.0.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f
+  sha256: d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3
 
 build:
   number: 0
@@ -18,7 +18,7 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
+    - setuptools >=45
     - wheel
   run:
     - python


### PR DESCRIPTION
async-timeout 5.0.1 main

- PKG-6326
- https://github.com/aio-libs/async-timeout/tree/v5.0.1